### PR TITLE
Remove increment/decrement buttons from top total game counter

### DIFF
--- a/__tests__/GameScreen.layout.test.tsx
+++ b/__tests__/GameScreen.layout.test.tsx
@@ -130,8 +130,8 @@ describe('GameScreen Layout Optimization', () => {
         </Provider>
       );
 
-      const team1Increment = getByTestId('team1-increment-button');
-      const team1Decrement = getByTestId('team1-decrement-button');
+      const team1Increment = getByTestId('team1-wins-increment-button');
+      const team1Decrement = getByTestId('team1-wins-decrement-button');
       const resetButton = getByTestId('reset-button');
 
       // Check touch targets are at least 44px
@@ -151,11 +151,11 @@ describe('GameScreen Layout Optimization', () => {
         </Provider>
       );
 
-      const team1Increment = getByTestId('team1-increment-button');
-      const team1Decrement = getByTestId('team1-decrement-button');
+      const team1Increment = getByTestId('team1-wins-increment-button');
+      const team1Decrement = getByTestId('team1-wins-decrement-button');
 
-      expect(team1Increment.props.accessibilityLabel).toBe('Increment team 1 wins');
-      expect(team1Decrement.props.accessibilityLabel).toBe('Decrement team 1 wins');
+      expect(team1Increment.props.accessibilityLabel).toBe('Increment team 1 games won');
+      expect(team1Decrement.props.accessibilityLabel).toBe('Decrement team 1 games won');
     });
   });
 

--- a/__tests__/GameScreen.orientation.test.tsx
+++ b/__tests__/GameScreen.orientation.test.tsx
@@ -202,7 +202,7 @@ describe('GameScreen Orientation Handling', () => {
       const tallyControls = getByTestId('tally-controls-container');
       expect(tallyControls).toBeTruthy();
 
-      const team1Increment = getByTestId('team1-increment-button');
+      const team1Increment = getByTestId('team1-wins-increment-button');
       expect(team1Increment).toBeTruthy();
     });
 

--- a/__tests__/GameScreen.test.tsx
+++ b/__tests__/GameScreen.test.tsx
@@ -319,12 +319,12 @@ describe('Visual Design Specification', () => {
       );
 
       // Increment team1 wins
-      fireEvent.press(getByTestId('team1-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
       expect(getByTestId('team1-wins-count')).toHaveTextContent('1');
       expect(getByTestId('total-game-counter')).toHaveTextContent('2'); // 1 + 0 + 1
 
       // Increment team2 wins
-      fireEvent.press(getByTestId('team2-increment-button'));
+      fireEvent.press(getByTestId('team2-wins-increment-button'));
       expect(getByTestId('team2-wins-count')).toHaveTextContent('1');
       expect(getByTestId('total-game-counter')).toHaveTextContent('3'); // 1 + 1 + 1
     });
@@ -350,12 +350,12 @@ describe('Visual Design Specification', () => {
       );
 
       // Decrement team1 wins
-      fireEvent.press(getByTestId('team1-decrement-button'));
+      fireEvent.press(getByTestId('team1-wins-decrement-button'));
       expect(getByTestId('team1-wins-count')).toHaveTextContent('1');
       expect(getByTestId('total-game-counter')).toHaveTextContent('3'); // 1 + 1 + 1
 
       // Decrement team2 wins
-      fireEvent.press(getByTestId('team2-decrement-button'));
+      fireEvent.press(getByTestId('team2-wins-decrement-button'));
       expect(getByTestId('team2-wins-count')).toHaveTextContent('0');
       expect(getByTestId('total-game-counter')).toHaveTextContent('2'); // 1 + 0 + 1
     });
@@ -407,8 +407,8 @@ describe('Visual Design Specification', () => {
       fireEvent.press(getByTestId('team1-decrement'));
 
       // Perform tally operations
-      fireEvent.press(getByTestId('team1-increment-button'));
-      fireEvent.press(getByTestId('team2-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
+      fireEvent.press(getByTestId('team2-wins-increment-button'));
 
       // Check that both systems work independently
       expect(getByTestId('team1-score')).toHaveTextContent('0'); // 1 - 1 = 0
@@ -432,7 +432,7 @@ describe('Visual Design Specification', () => {
       fireEvent(input, 'blur');
 
       // Increment wins
-      fireEvent.press(getByTestId('team1-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
 
       // Both features should work
       expect(getByTestId('team1-name')).toHaveTextContent('Winners');

--- a/__tests__/GameWinsIntegration.test.tsx
+++ b/__tests__/GameWinsIntegration.test.tsx
@@ -47,8 +47,8 @@ describe('Game Wins Integration', () => {
       // Set some scores and wins
       fireEvent.press(getByTestId('team1-score-area'));
       fireEvent.press(getByTestId('team2-score-area'));
-      fireEvent.press(getByTestId('team1-increment-button'));
-      fireEvent.press(getByTestId('team2-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
+      fireEvent.press(getByTestId('team2-wins-increment-button'));
 
       // Reset scores
       fireEvent.press(getByTestId('reset-button'));
@@ -83,11 +83,11 @@ describe('Game Wins Integration', () => {
         </Provider>
       );
 
-      fireEvent.press(getByTestId('team1-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
       expect(getByTestId('team1-wins-count')).toHaveTextContent('1');
 
-      fireEvent.press(getByTestId('team2-increment-button'));
-      fireEvent.press(getByTestId('team2-increment-button'));
+      fireEvent.press(getByTestId('team2-wins-increment-button'));
+      fireEvent.press(getByTestId('team2-wins-increment-button'));
       expect(getByTestId('team2-wins-count')).toHaveTextContent('2');
     });
   });
@@ -116,11 +116,11 @@ describe('Game Wins Integration', () => {
       expect(getByTestId('total-game-counter')).toHaveTextContent('1');
 
       // After incrementing: 1 + 0 + 1 = 2
-      fireEvent.press(getByTestId('team1-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
       expect(getByTestId('total-game-counter')).toHaveTextContent('2');
 
       // After incrementing both: 1 + 1 + 1 = 3
-      fireEvent.press(getByTestId('team2-increment-button'));
+      fireEvent.press(getByTestId('team2-wins-increment-button'));
       expect(getByTestId('total-game-counter')).toHaveTextContent('3');
     });
   });
@@ -134,7 +134,7 @@ describe('Game Wins Integration', () => {
         </Provider>
       );
 
-      fireEvent.press(getByTestId('team1-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
       expect(getByTestId('team1-wins-count')).toHaveTextContent('1');
     });
 
@@ -146,9 +146,9 @@ describe('Game Wins Integration', () => {
         </Provider>
       );
 
-      fireEvent.press(getByTestId('team1-increment-button'));
-      fireEvent.press(getByTestId('team1-increment-button'));
-      fireEvent.press(getByTestId('team1-decrement-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-decrement-button'));
       expect(getByTestId('team1-wins-count')).toHaveTextContent('1');
     });
 
@@ -160,7 +160,7 @@ describe('Game Wins Integration', () => {
         </Provider>
       );
 
-      fireEvent.press(getByTestId('team1-decrement-button'));
+      fireEvent.press(getByTestId('team1-wins-decrement-button'));
       expect(getByTestId('team1-wins-count')).toHaveTextContent('0');
     });
   });
@@ -181,7 +181,7 @@ describe('Game Wins Integration', () => {
       fireEvent(input, 'blur');
 
       // Verify tally functionality still works
-      fireEvent.press(getByTestId('team1-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
       expect(getByTestId('team1-wins-count')).toHaveTextContent('1');
 
       const state = store.getState().game;
@@ -200,7 +200,7 @@ describe('Game Wins Integration', () => {
       fireEvent.press(getByTestId('team1-score-area'));
 
       // Increment wins
-      fireEvent.press(getByTestId('team1-increment-button'));
+      fireEvent.press(getByTestId('team1-wins-increment-button'));
 
       const state = store.getState().game;
       expect(state.team1.score).toBe(1);

--- a/__tests__/TallyControls.test.tsx
+++ b/__tests__/TallyControls.test.tsx
@@ -1,32 +1,31 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import TallyControls from '../src/components/TallyControls';
 
 describe('TallyControls Component', () => {
   const mockProps = {
     team1Wins: 0,
     team2Wins: 0,
-    onIncrementTeam1: jest.fn(),
-    onDecrementTeam1: jest.fn(),
-    onIncrementTeam2: jest.fn(),
-    onDecrementTeam2: jest.fn(),
   };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('Rendering', () => {
-    test('should render increment/decrement buttons for both teams', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
+    test('should not render increment/decrement buttons', () => {
+      const { queryByTestId } = render(<TallyControls {...mockProps} />);
 
-      expect(getByTestId('team1-increment-button')).toBeTruthy();
-      expect(getByTestId('team1-decrement-button')).toBeTruthy();
-      expect(getByTestId('team2-increment-button')).toBeTruthy();
-      expect(getByTestId('team2-decrement-button')).toBeTruthy();
+      expect(queryByTestId('team1-increment-button')).toBeNull();
+      expect(queryByTestId('team1-decrement-button')).toBeNull();
+      expect(queryByTestId('team2-increment-button')).toBeNull();
+      expect(queryByTestId('team2-decrement-button')).toBeNull();
     });
 
-    test('should include TotalGameCounter component', () => {
+    test('should not render team control containers', () => {
+      const { queryByTestId } = render(<TallyControls {...mockProps} />);
+
+      expect(queryByTestId('team1-controls')).toBeNull();
+      expect(queryByTestId('team2-controls')).toBeNull();
+    });
+
+    test('should render only TotalGameCounter component', () => {
       const { getByTestId } = render(<TallyControls {...mockProps} />);
 
       expect(getByTestId('total-game-counter')).toBeTruthy();
@@ -35,7 +34,6 @@ describe('TallyControls Component', () => {
     test('should display correct total games calculation', () => {
       const { getByTestId } = render(
         <TallyControls
-          {...mockProps}
           team1Wins={2}
           team2Wins={1}
         />
@@ -45,198 +43,43 @@ describe('TallyControls Component', () => {
     });
   });
 
-  describe('Button interactions', () => {
-    test('should call onIncrementTeam1 when team1 increment button is pressed', () => {
+  describe('Component simplicity', () => {
+    test('should render simple container with centered layout', () => {
       const { getByTestId } = render(<TallyControls {...mockProps} />);
 
-      fireEvent.press(getByTestId('team1-increment-button'));
-
-      expect(mockProps.onIncrementTeam1).toHaveBeenCalledTimes(1);
+      const container = getByTestId('tally-controls-container');
+      expect(container).toBeTruthy();
     });
 
-    test('should call onDecrementTeam1 when team1 decrement button is pressed', () => {
+    test('should contain only TotalGameCounter as child', () => {
       const { getByTestId } = render(<TallyControls {...mockProps} />);
 
-      fireEvent.press(getByTestId('team1-decrement-button'));
-
-      expect(mockProps.onDecrementTeam1).toHaveBeenCalledTimes(1);
-    });
-
-    test('should call onIncrementTeam2 when team2 increment button is pressed', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      fireEvent.press(getByTestId('team2-increment-button'));
-
-      expect(mockProps.onIncrementTeam2).toHaveBeenCalledTimes(1);
-    });
-
-    test('should call onDecrementTeam2 when team2 decrement button is pressed', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      fireEvent.press(getByTestId('team2-decrement-button'));
-
-      expect(mockProps.onDecrementTeam2).toHaveBeenCalledTimes(1);
-    });
-
-    test('should handle multiple rapid button presses', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      const incrementButton = getByTestId('team1-increment-button');
-      fireEvent.press(incrementButton);
-      fireEvent.press(incrementButton);
-      fireEvent.press(incrementButton);
-
-      expect(mockProps.onIncrementTeam1).toHaveBeenCalledTimes(3);
-    });
-  });
-
-  describe('Layout and positioning', () => {
-    test('should have controls positioned in middle of screen', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      expect(getByTestId('tally-controls-container')).toHaveStyle({
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
-      });
-    });
-
-    test('should have team controls properly arranged', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      expect(getByTestId('team1-controls')).toHaveStyle({
-        flexDirection: 'column',
-        alignItems: 'center',
-      });
-
-      expect(getByTestId('team2-controls')).toHaveStyle({
-        flexDirection: 'column',
-        alignItems: 'center',
-      });
-    });
-
-    test('should position total game counter in center', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      // Verify all elements are present (order verification is implicit in layout)
-      expect(getByTestId('tally-controls-container')).toBeTruthy();
-      expect(getByTestId('team1-controls')).toBeTruthy();
+      expect(getByTestId('total-game-counter')).toBeTruthy();
       expect(getByTestId('total-game-container')).toBeTruthy();
-      expect(getByTestId('team2-controls')).toBeTruthy();
-    });
-  });
-
-  describe('Touch targets and accessibility', () => {
-    test('should have appropriate touch targets for mobile', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      const buttons = [
-        'team1-increment-button',
-        'team1-decrement-button',
-        'team2-increment-button',
-        'team2-decrement-button',
-      ];
-
-      buttons.forEach(buttonId => {
-        const button = getByTestId(buttonId);
-        expect(button).toHaveStyle({
-          minWidth: 44,
-          minHeight: 44,
-        });
-      });
-    });
-
-    test('should have proper accessibility labels', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      expect(getByTestId('team1-increment-button')).toHaveProp(
-        'accessibilityLabel',
-        'Increment team 1 wins'
-      );
-      expect(getByTestId('team1-decrement-button')).toHaveProp(
-        'accessibilityLabel',
-        'Decrement team 1 wins'
-      );
-      expect(getByTestId('team2-increment-button')).toHaveProp(
-        'accessibilityLabel',
-        'Increment team 2 wins'
-      );
-      expect(getByTestId('team2-decrement-button')).toHaveProp(
-        'accessibilityLabel',
-        'Decrement team 2 wins'
-      );
-    });
-
-    test('should have button accessibility role', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      const buttons = [
-        'team1-increment-button',
-        'team1-decrement-button',
-        'team2-increment-button',
-        'team2-decrement-button',
-      ];
-
-      buttons.forEach(buttonId => {
-        expect(getByTestId(buttonId)).toHaveProp('accessibilityRole', 'button');
-      });
-    });
-  });
-
-  describe('Visual design', () => {
-    test('should have unobtrusive button styling', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      const incrementButton = getByTestId('team1-increment-button');
-      expect(incrementButton).toHaveStyle({
-        backgroundColor: 'rgba(255, 255, 255, 0.1)',
-        borderRadius: 22,
-      });
-    });
-
-    test('should display + and - symbols correctly', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      expect(getByTestId('team1-increment-text')).toHaveTextContent('+');
-      expect(getByTestId('team1-decrement-text')).toHaveTextContent('-');
-      expect(getByTestId('team2-increment-text')).toHaveTextContent('+');
-      expect(getByTestId('team2-decrement-text')).toHaveTextContent('-');
-    });
-
-    test('should have consistent text styling', () => {
-      const { getByTestId } = render(<TallyControls {...mockProps} />);
-
-      const textElements = [
-        'team1-increment-text',
-        'team1-decrement-text',
-        'team2-increment-text',
-        'team2-decrement-text',
-      ];
-
-      textElements.forEach(textId => {
-        expect(getByTestId(textId)).toHaveStyle({
-          fontSize: 18,
-          color: 'rgba(255, 255, 255, 0.8)',
-          fontWeight: 'bold',
-        });
-      });
     });
   });
 
   describe('Component updates', () => {
     test('should update total games counter when win counts change', () => {
       const { getByTestId, rerender } = render(
-        <TallyControls {...mockProps} team1Wins={0} team2Wins={0} />
+        <TallyControls team1Wins={0} team2Wins={0} />
       );
 
       expect(getByTestId('total-game-counter')).toHaveTextContent('1');
 
       rerender(
-        <TallyControls {...mockProps} team1Wins={1} team2Wins={2} />
+        <TallyControls team1Wins={1} team2Wins={2} />
       );
 
       expect(getByTestId('total-game-counter')).toHaveTextContent('4');
+    });
+
+    test('should calculate total with different win values', () => {
+      const { getByTestId } = render(
+        <TallyControls team1Wins={5} team2Wins={3} />
+      );
+
+      expect(getByTestId('total-game-counter')).toHaveTextContent('9'); // 5 + 3 + 1
     });
   });
 });

--- a/remove-total-games-controls.spec.md
+++ b/remove-total-games-controls.spec.md
@@ -1,0 +1,356 @@
+# Remove Total Games Controls Specification
+
+## Feature Description
+Remove the increment/decrement buttons that appear beside the total game counter at the top of the screen. The increment/decrement controls should only appear next to the individual team "Games Won" values, not beside the total game number.
+
+## Requirements
+
+### Functional Requirements
+1. Remove increment/decrement buttons from the TallyControls component (top center of screen)
+2. The total game counter should display as read-only text showing the game number
+3. Team-specific games won increment/decrement controls should remain in TeamWinsTally components
+4. Total games calculation should remain: `team1Wins + team2Wins + 1`
+5. The total game counter should continue to update automatically when team wins change
+
+### Non-Functional Requirements
+1. Maintain existing test coverage (90% threshold)
+2. Preserve visual consistency with overall app design
+3. Ensure the total game counter remains clearly visible
+4. Maintain responsive layout in portrait and landscape modes
+5. No breaking changes to Redux state management
+
+## Current State Analysis
+
+### Current Components
+- **TallyControls**: Contains increment/decrement buttons for both teams and TotalGameCounter
+- **TotalGameCounter**: Displays the total game number
+- **TeamWinsTally**: Has inline controls for individual team games won (just implemented)
+
+### Components to Modify
+- **TallyControls**: Remove team control buttons, keep only TotalGameCounter
+- **GameScreen**: Remove TallyControls handlers, simplify top controls area
+
+### Components to Keep
+- **TotalGameCounter**: Keep as-is (read-only display)
+- **TeamWinsTally**: Keep as-is (has inline controls)
+
+## TDD Plan
+
+### Red-Green-Refactor Cycle
+
+#### Phase 1: Update TallyControls Tests
+**Red:**
+- Update TallyControls tests to expect only TotalGameCounter (no buttons)
+- Tests should fail because buttons still exist
+- Remove tests for button interactions
+- Keep tests for TotalGameCounter rendering and updates
+
+**Green:**
+- Simplify TallyControls to only render TotalGameCounter
+- Remove all button-related code
+- Remove props for handlers
+
+**Refactor:**
+- Clean up component structure
+- Update component documentation
+- Simplify prop interface
+
+#### Phase 2: Update GameScreen Tests
+**Red:**
+- Update GameScreen tests to expect simplified top controls
+- Remove expectations for TallyControls button handlers
+- Tests should verify TotalGameCounter is still rendered
+
+**Green:**
+- Remove handler props passed to TallyControls
+- Simplify top controls container if needed
+
+**Refactor:**
+- Clean up unused handler functions
+- Optimize component structure
+
+#### Phase 3: Integration Tests
+**Red:**
+- Update GameWinsIntegration tests if they reference TallyControls buttons
+- Ensure tests focus on TeamWinsTally controls only
+
+**Green:**
+- Update integration tests to use TeamWinsTally controls
+- Verify total games counter updates correctly
+
+**Refactor:**
+- Consolidate test helpers
+- Remove obsolete test utilities
+
+## Test Categories
+
+### Unit Tests
+
+#### TallyControls Component Tests
+- **Rendering**
+  - Renders TotalGameCounter component
+  - Does NOT render increment buttons
+  - Does NOT render decrement buttons
+  - Does NOT render team control containers
+
+- **Display**
+  - Displays correct total games (team1Wins + team2Wins + 1)
+  - Updates when team wins change
+  - Maintains layout styling
+
+- **Props**
+  - Accepts team1Wins prop
+  - Accepts team2Wins prop
+  - Does NOT accept handler props
+
+#### GameScreen Component Tests
+- **Top Controls**
+  - Renders top controls container
+  - Renders TotalGameCounter in top controls
+  - Does NOT pass handler props to TallyControls
+
+### Integration Tests
+- **Games Won Workflow**
+  - Incrementing team wins via TeamWinsTally updates total counter
+  - Decrementing team wins via TeamWinsTally updates total counter
+  - Total games counter shows correct calculation
+
+### Cleanup Tests
+- Verify removed tests no longer exist
+- Ensure no orphaned test utilities
+- Validate all test suites still pass
+
+## Architecture Design
+
+### Before (Current State)
+```
+TallyControls
+├── Team 1 Controls (column)
+│   ├── Decrement Button
+│   └── Increment Button
+├── TotalGameCounter
+└── Team 2 Controls (column)
+    ├── Decrement Button
+    └── Increment Button
+```
+
+### After (Target State)
+```
+TallyControls
+└── TotalGameCounter (read-only)
+```
+
+### Props Interface Change
+
+**Before:**
+```typescript
+interface TallyControlsProps {
+  team1Wins: number;
+  team2Wins: number;
+  onIncrementTeam1: () => void;
+  onDecrementTeam1: () => void;
+  onIncrementTeam2: () => void;
+  onDecrementTeam2: () => void;
+}
+```
+
+**After:**
+```typescript
+interface TallyControlsProps {
+  team1Wins: number;
+  team2Wins: number;
+}
+```
+
+### GameScreen Changes
+
+**Before:**
+```tsx
+<TallyControls
+  team1Wins={gameWins.team1}
+  team2Wins={gameWins.team2}
+  onIncrementTeam1={handleIncrementTeam1Wins}
+  onDecrementTeam1={handleDecrementTeam1Wins}
+  onIncrementTeam2={handleIncrementTeam2Wins}
+  onDecrementTeam2={handleDecrementTeam2Wins}
+/>
+```
+
+**After:**
+```tsx
+<TallyControls
+  team1Wins={gameWins.team1}
+  team2Wins={gameWins.team2}
+/>
+```
+
+## Implementation Phases
+
+### Phase 1: Test Updates
+1. Update TallyControls.test.tsx
+   - Remove button rendering tests
+   - Remove button interaction tests
+   - Remove accessibility tests for buttons
+   - Keep TotalGameCounter tests
+   - Keep layout tests (simplified)
+
+2. Update GameScreen tests
+   - Remove TallyControls handler tests
+   - Keep top controls rendering tests
+   - Verify TotalGameCounter still works
+
+3. Update integration tests
+   - Remove references to TallyControls buttons
+   - Focus on TeamWinsTally controls
+
+### Phase 2: Component Implementation
+1. Simplify TallyControls component
+   - Remove all TouchableOpacity buttons
+   - Remove handler props from interface
+   - Keep only TotalGameCounter rendering
+   - Update component documentation
+
+2. Update GameScreen component
+   - Remove handler props from TallyControls usage
+   - Optionally simplify topControls styles
+   - Keep handler functions for TeamWinsTally
+
+### Phase 3: Cleanup
+1. Remove unused code
+   - Delete handler functions if only used by TallyControls
+   - Actually, keep handlers - they're used by TeamWinsTally
+   - Clean up imports if any become unused
+
+2. Update documentation
+   - Update component comments
+   - Update CLAUDE.md if needed
+
+### Phase 4: Verification
+1. Run all tests
+2. Verify 90% coverage maintained
+3. Run linting
+4. Run type checking
+
+## Testing Strategy
+
+### Test Data
+- Team wins: 0, 1, 5, 10
+- Total games: 1, 2, 6, 11, 21
+
+### Test Scenarios
+
+1. **Component Rendering**
+   - TallyControls renders with only TotalGameCounter
+   - No buttons are present in component tree
+   - Layout is simplified and centered
+
+2. **Total Games Calculation**
+   - With team1=0, team2=0: total=1
+   - With team1=2, team2=3: total=6
+   - With team1=10, team2=10: total=21
+
+3. **Updates**
+   - Changing team1Wins updates total
+   - Changing team2Wins updates total
+   - Component re-renders correctly
+
+4. **Integration**
+   - TeamWinsTally controls work independently
+   - Changes reflect in top TotalGameCounter
+   - No broken handlers or props
+
+### Coverage Goals
+- Maintain 90% overall coverage
+- 100% coverage of simplified TallyControls
+- All interaction paths via TeamWinsTally tested
+
+## Definition of Done
+
+### Code Complete
+- [ ] TallyControls component simplified (buttons removed)
+- [ ] TallyControls props interface updated (handlers removed)
+- [ ] GameScreen updated (no handler props to TallyControls)
+- [ ] All tests updated and passing
+- [ ] Code coverage ≥ 90%
+- [ ] TypeScript type checking passing
+- [ ] ESLint passing with 0 warnings
+
+### Tests Complete
+- [ ] TallyControls tests updated (no button tests)
+- [ ] GameScreen tests updated (no handler tests)
+- [ ] Integration tests updated (focus on TeamWinsTally)
+- [ ] All removed tests documented
+- [ ] All new/updated tests passing
+
+### Functionality Complete
+- [ ] TallyControls displays only total game number
+- [ ] No increment/decrement buttons in top controls
+- [ ] TeamWinsTally controls still work for both teams
+- [ ] Total games counter updates when team wins change
+- [ ] Layout looks clean and centered
+
+### Quality Complete
+- [ ] No visual regressions
+- [ ] Responsive layout maintained
+- [ ] Accessibility maintained (where applicable)
+- [ ] Performance remains optimal
+- [ ] Code follows project conventions
+- [ ] Documentation updated
+
+## Acceptance Criteria
+
+1. **TallyControls Component**
+   - The TallyControls component renders only the TotalGameCounter
+   - No increment buttons are visible in the top controls area
+   - No decrement buttons are visible in the top controls area
+   - The component accepts only team1Wins and team2Wins props
+
+2. **Total Game Counter**
+   - The total game number is displayed in the top center of the screen
+   - The total is calculated as: team1Wins + team2Wins + 1
+   - The counter updates automatically when team wins change
+   - The counter is read-only (no direct interaction)
+
+3. **Team Games Won Controls**
+   - Team 1 games won controls appear in TeamWinsTally component (bottom left in portrait, left side in landscape)
+   - Team 2 games won controls appear in TeamWinsTally component (bottom right in portrait, right side in landscape)
+   - Both teams have working increment (+) and decrement (-) buttons
+   - Changes to team wins update the top total game counter
+
+4. **Layout and Styling**
+   - The top controls area is simplified and centered
+   - The total game counter is clearly visible
+   - Layout works in both portrait and landscape orientations
+   - No layout regressions or visual glitches
+
+5. **Code Quality**
+   - All tests pass (182 tests or adjusted count)
+   - Test coverage remains at or above 90%
+   - No TypeScript errors
+   - No ESLint warnings
+   - Code is clean and well-documented
+
+## Notes
+
+### Why This Change
+- Reduces duplication: games won controls appeared in two places (top and bottom)
+- Improves clarity: total game number is now clearly read-only
+- Simplifies UI: cleaner top area with just the game number
+- Aligns with recent change: inline controls in TeamWinsTally make top controls redundant
+
+### User Impact
+- Users now adjust games won using only the controls next to each team's tally
+- The top counter becomes a pure display element showing which game is being played
+- More intuitive: controls are co-located with the values they modify
+
+### Technical Considerations
+- Handler functions in GameScreen are still needed for TeamWinsTally
+- Redux actions remain unchanged
+- State management remains unchanged
+- Only UI component structure changes
+
+### Risk Assessment
+- **Low Risk**: This is primarily a UI simplification
+- Tests will catch any regressions
+- No changes to state management or business logic
+- Easy to revert if needed

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -132,15 +132,11 @@ const GameScreen: React.FC = () => {
         />
       </View>
 
-      {/* Top Controls - TallyControls at top of screen */}
+      {/* Top Controls - Total Game Counter */}
       <View testID="top-controls-container" style={styles.topControls}>
         <TallyControls
           team1Wins={gameWins.team1}
           team2Wins={gameWins.team2}
-          onIncrementTeam1={handleIncrementTeam1Wins}
-          onDecrementTeam1={handleDecrementTeam1Wins}
-          onIncrementTeam2={handleIncrementTeam2Wins}
-          onDecrementTeam2={handleDecrementTeam2Wins}
         />
       </View>
 

--- a/src/components/TallyControls.tsx
+++ b/src/components/TallyControls.tsx
@@ -1,110 +1,40 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import TotalGameCounter from './TotalGameCounter';
 
+/**
+ * TallyControls - Displays the total game counter
+ *
+ * This component is a simple wrapper around TotalGameCounter that displays
+ * which game is currently being played (calculated as team1Wins + team2Wins + 1).
+ *
+ * Individual team games won controls are located in the TeamWinsTally components
+ * at the bottom of each team's side.
+ */
 interface TallyControlsProps {
+  /** Number of games won by team 1 */
   team1Wins: number;
+  /** Number of games won by team 2 */
   team2Wins: number;
-  onIncrementTeam1: () => void;
-  onDecrementTeam1: () => void;
-  onIncrementTeam2: () => void;
-  onDecrementTeam2: () => void;
 }
 
 const TallyControls: React.FC<TallyControlsProps> = ({
   team1Wins,
   team2Wins,
-  onIncrementTeam1,
-  onDecrementTeam1,
-  onIncrementTeam2,
-  onDecrementTeam2,
 }) => {
   const totalGames = team1Wins + team2Wins + 1;
 
   return (
     <View testID="tally-controls-container" style={styles.controlsContainer}>
-      {/* Team 1 Controls */}
-      <View testID="team1-controls" style={styles.teamControls}>
-        <TouchableOpacity
-          testID="team1-decrement-button"
-          style={styles.controlButton}
-          onPress={onDecrementTeam1}
-          accessibilityLabel="Decrement team 1 wins"
-          accessibilityRole="button"
-        >
-          <Text testID="team1-decrement-text" style={styles.buttonText}>
-            -
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          testID="team1-increment-button"
-          style={styles.controlButton}
-          onPress={onIncrementTeam1}
-          accessibilityLabel="Increment team 1 wins"
-          accessibilityRole="button"
-        >
-          <Text testID="team1-increment-text" style={styles.buttonText}>
-            +
-          </Text>
-        </TouchableOpacity>
-      </View>
-
-      {/* Total Game Counter */}
       <TotalGameCounter totalGames={totalGames} />
-
-      {/* Team 2 Controls */}
-      <View testID="team2-controls" style={styles.teamControls}>
-        <TouchableOpacity
-          testID="team2-decrement-button"
-          style={styles.controlButton}
-          onPress={onDecrementTeam2}
-          accessibilityLabel="Decrement team 2 wins"
-          accessibilityRole="button"
-        >
-          <Text testID="team2-decrement-text" style={styles.buttonText}>
-            -
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          testID="team2-increment-button"
-          style={styles.controlButton}
-          onPress={onIncrementTeam2}
-          accessibilityLabel="Increment team 2 wins"
-          accessibilityRole="button"
-        >
-          <Text testID="team2-increment-text" style={styles.buttonText}>
-            +
-          </Text>
-        </TouchableOpacity>
-      </View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   controlsContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    width: '100%',
-  },
-  teamControls: {
-    flexDirection: 'column',
-    alignItems: 'center',
-  },
-  controlButton: {
-    minWidth: 44,
-    minHeight: 44,
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-    borderRadius: 22,
     justifyContent: 'center',
-    alignItems: 'center',
-    marginVertical: 2,
-  },
-  buttonText: {
-    fontSize: 18,
-    color: 'rgba(255, 255, 255, 0.8)',
-    fontWeight: 'bold',
   },
 });
 


### PR DESCRIPTION
Simplifies TallyControls to display only total game counter (read-only). Removes duplicate controls - game wins now modified only via TeamWinsTally inline controls. 172 tests passing, 98% coverage.